### PR TITLE
Switch API client to async httpx

### DIFF
--- a/modules/api/client.py
+++ b/modules/api/client.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 import logging
 import json
 from modules.config import API_BASE_URL, API_TOKEN
@@ -19,14 +19,22 @@ class RemnaAPI:
     async def get(endpoint, params=None):
         """Make a GET request to the API"""
         try:
-            response = requests.get(f"{API_BASE_URL}/{endpoint}", headers=get_headers(), params=params)
-            response.raise_for_status()
-            json_response = response.json()
-            return json_response.get("response") if isinstance(json_response, dict) else json_response
-        except requests.exceptions.RequestException as e:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{API_BASE_URL}/{endpoint}",
+                    headers=get_headers(),
+                    params=params,
+                )
+                response.raise_for_status()
+                json_response = response.json()
+                return json_response.get("response") if isinstance(json_response, dict) else json_response
+        except httpx.HTTPStatusError as e:
             logger.error(f"API GET error: {endpoint} - {str(e)}")
-            if hasattr(e, 'response') and e.response:
+            if e.response is not None:
                 logger.error(f"Response: {e.response.status_code} - {e.response.text}")
+            return None
+        except httpx.RequestError as e:
+            logger.error(f"API GET request error: {endpoint} - {str(e)}")
             return None
         except Exception as e:
             logger.error(f"Unexpected error in GET {endpoint}: {str(e)}")
@@ -38,27 +46,34 @@ class RemnaAPI:
         try:
             # Log request data for debugging
             logger.debug(f"POST request to {endpoint} with data: {json.dumps(data, indent=2)}")
-            
-            response = requests.post(f"{API_BASE_URL}/{endpoint}", headers=get_headers(), json=data)
-            
+
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{API_BASE_URL}/{endpoint}",
+                    headers=get_headers(),
+                    json=data,
+                )
+
             # Log response status and content for debugging
             logger.debug(f"Response status: {response.status_code}")
             logger.debug(f"Response content: {response.text[:500]}...")  # Log first 500 chars to avoid huge logs
-            
+
             response.raise_for_status()
             json_response = response.json()
             return json_response.get("response") if isinstance(json_response, dict) else json_response
-        except requests.exceptions.RequestException as e:
+        except httpx.HTTPStatusError as e:
             logger.error(f"API POST error: {endpoint} - {str(e)}")
-            if hasattr(e, 'response') and e.response:
+            if e.response is not None:
                 logger.error(f"Response: {e.response.status_code} - {e.response.text}")
-                # Try to parse error response if possible
                 try:
                     error_json = e.response.json()
                     if "message" in error_json:
                         logger.error(f"API error message: {error_json['message']}")
-                except:
+                except Exception:
                     pass
+            return None
+        except httpx.RequestError as e:
+            logger.error(f"API POST request error: {endpoint} - {str(e)}")
             return None
         except Exception as e:
             logger.error(f"Unexpected error in POST {endpoint}: {str(e)}")
@@ -70,15 +85,23 @@ class RemnaAPI:
         try:
             # Логируем данные запроса для отладки
             logger.debug(f"PATCH request to {endpoint} with data: {json.dumps(data, indent=2)}")
-            
-            response = requests.patch(f"{API_BASE_URL}/{endpoint}", headers=get_headers(), json=data)
+
+            async with httpx.AsyncClient() as client:
+                response = await client.patch(
+                    f"{API_BASE_URL}/{endpoint}",
+                    headers=get_headers(),
+                    json=data,
+                )
             response.raise_for_status()
             json_response = response.json()
             return json_response.get("response") if isinstance(json_response, dict) else json_response
-        except requests.exceptions.RequestException as e:
+        except httpx.HTTPStatusError as e:
             logger.error(f"API PATCH error: {endpoint} - {str(e)}")
-            if hasattr(e, 'response') and e.response:
+            if e.response is not None:
                 logger.error(f"Response: {e.response.status_code} - {e.response.text}")
+            return None
+        except httpx.RequestError as e:
+            logger.error(f"API PATCH request error: {endpoint} - {str(e)}")
             return None
         except Exception as e:
             logger.error(f"Unexpected error in PATCH {endpoint}: {str(e)}")
@@ -88,15 +111,49 @@ class RemnaAPI:
     async def delete(endpoint, params=None):
         """Make a DELETE request to the API"""
         try:
-            response = requests.delete(f"{API_BASE_URL}/{endpoint}", headers=get_headers(), params=params)
+            async with httpx.AsyncClient() as client:
+                response = await client.delete(
+                    f"{API_BASE_URL}/{endpoint}",
+                    headers=get_headers(),
+                    params=params,
+                )
             response.raise_for_status()
             json_response = response.json()
             return json_response.get("response") if isinstance(json_response, dict) else json_response
-        except requests.exceptions.RequestException as e:
+        except httpx.HTTPStatusError as e:
             logger.error(f"API DELETE error: {endpoint} - {str(e)}")
-            if hasattr(e, 'response') and e.response:
+            if e.response is not None:
                 logger.error(f"Response: {e.response.status_code} - {e.response.text}")
+            return None
+        except httpx.RequestError as e:
+            logger.error(f"API DELETE request error: {endpoint} - {str(e)}")
             return None
         except Exception as e:
             logger.error(f"Unexpected error in DELETE {endpoint}: {str(e)}")
+            return None
+
+    @staticmethod
+    async def put(endpoint, data=None):
+        """Make a PUT request to the API"""
+        try:
+            logger.debug(f"PUT request to {endpoint} with data: {json.dumps(data, indent=2)}")
+            async with httpx.AsyncClient() as client:
+                response = await client.put(
+                    f"{API_BASE_URL}/{endpoint}",
+                    headers=get_headers(),
+                    json=data,
+                )
+            response.raise_for_status()
+            json_response = response.json()
+            return json_response.get("response") if isinstance(json_response, dict) else json_response
+        except httpx.HTTPStatusError as e:
+            logger.error(f"API PUT error: {endpoint} - {str(e)}")
+            if e.response is not None:
+                logger.error(f"Response: {e.response.status_code} - {e.response.text}")
+            return None
+        except httpx.RequestError as e:
+            logger.error(f"API PUT request error: {endpoint} - {str(e)}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error in PUT {endpoint}: {str(e)}")
             return None

--- a/remnawave_admin_bot.py
+++ b/remnawave_admin_bot.py
@@ -54,4 +54,3 @@ if __name__ == '__main__':
         logger.info("Bot stopped!")
     except Exception as e:
         logger.error(f"Error in main: {e}", exc_info=True)
-\`\`\`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-telegram-bot==20.6
 python-dotenv==1.0.0
-requests==2.31.0
+httpx==0.25.2


### PR DESCRIPTION
## Summary
- use `httpx` async client instead of `requests`
- implement missing PUT method
- update requirements
- fix stray markup in `remnawave_admin_bot.py`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875024452ac8321809c87611780a32a