### PR TITLE
Fix Markdown entity parsing in user details

### DIFF
--- a/modules/utils/formatters.py
+++ b/modules/utils/formatters.py
@@ -54,7 +54,8 @@ def format_user_details(user):
     
     message += f"📊 *Статус:* {status_emoji} {user['status']}\n"
     message += f"📈 *Трафик:* {format_bytes(user['usedTrafficBytes'])}/{format_bytes(user['trafficLimitBytes'])}\n"
-    message += f"🔄 *Стратегия сброса:* {user['trafficLimitStrategy']}\n"
+    # Escape strategy in case it contains underscores or other markdown symbols
+    message += f"🔄 *Стратегия сброса:* {escape_markdown(user['trafficLimitStrategy'])}\n"
     message += f"{expire_status} *Истекает:* {expire_text}\n\n"
     
     if user.get('description'):


### PR DESCRIPTION
## Summary
- escape `trafficLimitStrategy` field in user detail formatting to avoid Telegram Markdown errors

## Testing
- `python -m py_compile modules/utils/formatters.py modules/handlers/user_handlers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687518dc1f5c8321a41a069a05413848