### PR TITLE
Fix user creation flow

### DIFF
--- a/modules/handlers/menu_handler.py
+++ b/modules/handlers/menu_handler.py
@@ -2,7 +2,16 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 from modules.utils.auth import check_admin
 
-from modules.config import MAIN_MENU, USER_MENU, NODE_MENU, STATS_MENU, HOST_MENU, INBOUND_MENU, BULK_MENU
+from modules.config import (
+    MAIN_MENU,
+    USER_MENU,
+    NODE_MENU,
+    STATS_MENU,
+    HOST_MENU,
+    INBOUND_MENU,
+    BULK_MENU,
+    CREATE_USER_FIELD,
+)
 from modules.handlers.user_handlers import show_users_menu, start_create_user
 from modules.handlers.node_handlers import show_nodes_menu
 from modules.handlers.stats_handlers import show_stats_menu
@@ -73,6 +82,6 @@ async def handle_menu_selection(update: Update, context: ContextTypes.DEFAULT_TY
 
     elif data == "create_user" or data == "menu_create_user":
         await start_create_user(update, context)
-        return USER_MENU
+        return CREATE_USER_FIELD
 
     return MAIN_MENU

--- a/modules/handlers/user_handlers.py
+++ b/modules/handlers/user_handlers.py
@@ -92,7 +92,7 @@ async def handle_users_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     elif data == "create_user" or data == "menu_create_user":
         await start_create_user(update, context)
-        return CREATE_USER
+        return CREATE_USER_FIELD
 
     elif data == "back_to_main":
         await show_main_menu(update, context)
@@ -1122,7 +1122,7 @@ async def start_create_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # Start asking for fields
     await ask_for_field(update, context)
-    return CREATE_USER
+    return CREATE_USER_FIELD
 
 async def ask_for_field(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Ask for a field value when creating a user"""
@@ -1209,7 +1209,7 @@ async def handle_create_user_input(update: Update, context: ContextTypes.DEFAULT
             # Skip this field
             context.user_data["current_field_index"] += 1
             await ask_for_field(update, context)
-            return CREATE_USER
+            return CREATE_USER_FIELD
         
         elif data == "cancel_create":
             # Cancel user creation
@@ -1226,7 +1226,7 @@ async def handle_create_user_input(update: Update, context: ContextTypes.DEFAULT
             context.user_data["create_user"][field] = value
             context.user_data["current_field_index"] += 1
             await ask_for_field(update, context)
-            return CREATE_USER
+            return CREATE_USER_FIELD
 
     else:  # Text input
         try:
@@ -1338,10 +1338,10 @@ async def handle_create_user_input(update: Update, context: ContextTypes.DEFAULT
             # Store the value and move to the next field
             context.user_data["create_user"][field] = value
             context.user_data["current_field_index"] += 1
-            
+
             # Ask for the next field
             await ask_for_field(update, context)
-            return CREATE_USER
+            return CREATE_USER_FIELD
             
         except Exception as e:
             # Handle any unexpected errors


### PR DESCRIPTION
## Summary
- return the right state for user creation workflow so text input is handled
- allow starting user creation from main menu correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751b5758288321902636138e9a254f